### PR TITLE
added table value parsing to interpolateValue

### DIFF
--- a/i18n/interpolate.lua
+++ b/i18n/interpolate.lua
@@ -7,6 +7,19 @@ local function interpolateValue(string, variables)
       if previous == "%" then
         return
       else
+        if key:match('%.') then
+          -- it's a table reference
+          local value = variables
+          for sub_key in key:gmatch('[^.]+') do
+            if value[sub_key] then
+              value = value[sub_key]
+            else
+              return previous .. tostring(variables [key])
+            end
+          end
+          return previous .. tostring(value)
+        end
+
         return previous .. tostring(variables [key])
       end
     end)


### PR DESCRIPTION
Changed interpolateValue so that one can use %{some_table.sub_table.some_value} to reference value in variables.some_table.sub_table.some_value.
Same code should work for interpolateField too, so this could probably be made into a function to be used inside both said function.

Tested with lua5.3 and luajit, works fine. Will cause problems if user has used dots in variable names (variables['some.dotted.stuff'])