### PR TITLE
Added support for arrays of strings to i18n. Arrays support pluralisa…

### DIFF
--- a/i18n/interpolate.lua
+++ b/i18n/interpolate.lua
@@ -1,10 +1,28 @@
 local unpack = unpack or table.unpack -- lua 5.2 compat
 
+local interpolate = {}
+
 local FORMAT_CHARS = { c=1, d=1, E=1, e=1, f=1, g=1, G=1, i=1, o=1, u=1, X=1, x=1, s=1, q=1, ['%']=1 }
+
+local fieldPattern = "(.?)%%{%s*(.-)%s*}"
+local valuePattern = "(.?)%%<%s*(.-)%s*>%.([cdEefgGiouXxsq])"
+function interpolate.getInterpolationKey(string, variables)
+  for previous, key in string:gmatch(fieldPattern) do
+    if previous ~= "%" and variables[key] then
+      return key
+    end
+  end
+
+  for previous, key in string:gmatch(valuePattern) do
+    if previous ~= "%" and variables[key] then
+      return key
+    end
+  end
+end
 
 -- matches a string of type %{age}
 local function interpolateValue(string, variables)
-  return string:gsub("(.?)%%{%s*(.-)%s*}",
+  return string:gsub(fieldPattern,
     function (previous, key)
       if previous == "%" then
         return
@@ -16,7 +34,7 @@ end
 
 -- matches a string of type %<age>.d
 local function interpolateField(string, variables)
-  return string:gsub("(.?)%%<%s*(.-)%s*>%.([cdEefgGiouXxsq])",
+  return string:gsub(valuePattern,
     function (previous, key, format)
       if previous == "%" then
         return
@@ -46,7 +64,7 @@ local function unescapePercentages(string)
   end)
 end
 
-local function interpolate(pattern, variables)
+local function interpolateString(pattern, variables)
   variables = variables or {}
   local result = pattern
   result = interpolateValue(result, variables)
@@ -56,5 +74,7 @@ local function interpolate(pattern, variables)
   result = unescapePercentages(result)
   return result
 end
+
+setmetatable(interpolate, {__call = function(_, ...) return interpolateString(...) end})
 
 return interpolate

--- a/spec/i18n_interpolate_spec.lua
+++ b/spec/i18n_interpolate_spec.lua
@@ -4,7 +4,7 @@ local interpolate = require 'i18n.interpolate'
 
 describe('i18n.interpolate', function()
   it("exists", function()
-    assert.equal('function', type(interpolate))
+    assert.equal('table', type(interpolate))
   end)
 
   it("performs standard interpolation via string.format", function()

--- a/spec/i18n_spec.lua
+++ b/spec/i18n_spec.lua
@@ -153,6 +153,72 @@ describe('i18n', function()
     end)
   end)
 
+  describe('arrays', function()
+    it("Load supports arrays of strings", function()
+      i18n.set('en.array', {"one", "two", "three"})
+      assert.same({"one", "two", "three"},i18n('array'))
+    end)
+
+    it("Arrays respect languages", function()
+      i18n.set('en.array', {"one", "two", "three"})
+      i18n.set('fr.array', {"un", "deux", "trois"})
+      i18n.setLocale('fr')
+      assert.same({"un", "deux", "trois"},i18n('array'))
+    end)
+
+    it("Variables in array elements can be interpolated", function()
+      i18n.set('en.suede', {"%{count} for the count", "%{show} for the show", "%{ready} to make ready", "go!"})
+      assert.same({
+        "one for the count",
+        "two for the show",
+        "three to make ready",
+        "go!"
+      },i18n('suede',{count = "one", show = "two", ready = "three"}))
+    end)
+
+    it("Variables in array elements can be pluralized", function()
+      i18n.set('en.safe', {"Welcome to Apature!", {
+        one = "%{count} unfortunate retirement today!",
+        other = "%{count} unfortunate retirements today!"}
+      })
+      assert.same({
+        "Welcome to Apature!",
+        "1 unfortunate retirement today!",
+      },i18n('safe',{count = 1}))
+    end)
+
+    it("Variables in array elements can be pluralized independently", function()
+      i18n.set('en.safe', {
+        "Welcome to Apature!", {
+          one = "%{count} unfortunate retirement today!",
+          other = "%{count} unfortunate retirements today!"
+        }, {
+          one = "only %{test} test subject active!",
+          other = "%{test} test subjects active"
+        }
+      })
+      assert.same({
+        "Welcome to Apature!",
+        "10 unfortunate retirements today!",
+        "only 1 test subject active!"
+      },i18n('safe',{count = 10, test = 1}))
+    end)
+
+    it("Without field or value names in string. Pluralisation assumes count as default key", function()
+      i18n.set('en.safe', {
+        "Welcome to Apature!", {
+          one = "It's great!",
+          other = "It's mostly safe!"
+        }
+      })
+      assert.same({
+        "Welcome to Apature!",
+        "It's mostly safe!",
+     },i18n('safe',{count = 2}))
+    end)
+
+  end)
+
   describe('set/getFallbackLocale', function()
     it("defaults to en", function()
       assert.equal('en', i18n.getFallbackLocale())


### PR DESCRIPTION
Hi, this is my attempt to add support for #29 

I've changed the way pluralisation works to support this. Whereas previously the code always used data.count to determine the pluralisation it now uses the first `%{field}` or `%<value>` name in the string, falling back to count if none found.

This will cause issues if the user attempts to combine pluralisation and interpolation with independent variables at the same time. At the moment I cannot think of a use case for this. 