### PR TITLE
Added default value for count

### DIFF
--- a/i18n/init.lua
+++ b/i18n/init.lua
@@ -79,7 +79,18 @@ local function treatNode(node, data)
   if type(node) == 'string' then
     return interpolate(node, data)
   elseif isPluralTable(node) then
-    return interpolate(pluralize(node, data), data)
+    -- Make sure that count has a default of 1
+    local newdata
+    if data.count == nil then
+        newdata = {}
+        for key, value in pairs(data) do
+            newdata[key] = value
+        end
+        newdata.count = 1
+    else
+        newdata = data
+    end
+    return interpolate(pluralize(node, newdata), newdata)
   end
   return node
 end

--- a/spec/i18n_spec.lua
+++ b/spec/i18n_spec.lua
@@ -91,20 +91,21 @@ describe('i18n', function()
         before_each(function()
           i18n.setLocale('fr')
           i18n.set('fr.message', {
-            one   = "Une chose.",
+            one   = "%{count} chose.",
             other = "%{count} choses."
           })
         end)
 
         it('Ça marche', function()
-          assert.equal("Une chose.", i18n('message', {count = 1}))
-          assert.equal("Une chose.", i18n('message', {count = 1.5}))
+          assert.equal("1 chose.", i18n('message', {count = 1}))
+          -- Note: should actually be '1,5 chose.'
+          assert.equal("1.5 chose.", i18n('message', {count = 1.5}))
           assert.equal("2 choses.", i18n('message', {count = 2}))
-          assert.equal("Une chose.", i18n('message', {count = 0}))
+          assert.equal("0 chose.", i18n('message', {count = 0}))
         end)
 
         it('defaults to 1', function()
-          assert.equal("Une chose.", i18n('message'))
+          assert.equal("1 chose.", i18n('message'))
         end)
       end)
 


### PR DESCRIPTION
If `count` is used in a message, but not passed as a variable, it should provide a meaningful default.

I'm not really sure why you would want to implement a plural message without a `count` argument, but the tests didn't really make sense:

`assert.equal("Une chose.", i18n('message', {count = 0}))` is clearly incorrect, as while `0` is in the same CLDR plural category as `1` in French, it doesn't mean the same thing. So without the ability to match against numerical constants in addition to CLDR plural categories, it only works to have the message be:

```
i18n.set('fr.message', {
    one   = "%{count} chose.",
    other = "%{count} choses."
})
```

But then the `defaults to 1` test produces `nil chose.`, which isn't helpful, so we need a default value for `count` as well as a default plural category for it.